### PR TITLE
set unicode flags by default

### DIFF
--- a/src/Data/String/Regex/Flags.purs
+++ b/src/Data/String/Regex/Flags.purs
@@ -25,7 +25,7 @@ noFlags = RegexFlags
   , ignoreCase: false
   , multiline: false
   , sticky: false
-  , unicode: false
+  , unicode: true
   }
 
 -- | Only global flag set to true
@@ -35,7 +35,7 @@ global = RegexFlags
   , ignoreCase: false
   , multiline: false
   , sticky: false
-  , unicode: false
+  , unicode: true
   }
 
 -- | Only ignoreCase flag set to true
@@ -45,7 +45,7 @@ ignoreCase = RegexFlags
   , ignoreCase: true
   , multiline: false
   , sticky: false
-  , unicode: false
+  , unicode: true
   }
 
 -- | Only multiline flag set to true
@@ -55,7 +55,7 @@ multiline = RegexFlags
   , ignoreCase: false
   , multiline: true
   , sticky: false
-  , unicode: false
+  , unicode: true
   }
 
 -- | Only sticky flag set to true
@@ -65,17 +65,17 @@ sticky = RegexFlags
   , ignoreCase: false
   , multiline: false
   , sticky: true
-  , unicode: false
+  , unicode: true
   }
 
--- | Only unicode flag set to true
-unicode :: RegexFlags
-unicode = RegexFlags
+-- | Disable unicode flag
+noUnicode :: RegexFlags
+noUnicode = RegexFlags
   { global: false
   , ignoreCase: false
   , multiline: false
   , sticky: false
-  , unicode: true
+  , unicode: false
   }
 
 instance semigroupRegexFlags :: Semigroup RegexFlags where

--- a/test/Test/Data/String/Regex.purs
+++ b/test/Test/Data/String/Regex.purs
@@ -24,6 +24,7 @@ testStringRegex = do
   assert $ "quxbarfoobaz" == replace (unsafeRegex "foo" noFlags) "qux" "foobarfoobaz"
   assert $ "quxbarquxbaz" == replace (unsafeRegex "foo" global) "qux" "foobarfoobaz"
   assert $ "quxbarquxbaz" == replace (unsafeRegex "foo" (global <> ignoreCase)) "qux" "foobarFOObaz"
+  assert $ "a table !" == replace (unsafeRegex "à" noFlags) "a" "à table !"
 
   log "match"
   assert $ match (unsafeRegex "^abc$" noFlags) "abc" == Just [Just "abc"]


### PR DESCRIPTION
Hi there!

I've been using purerl a lot lately to help me convert my elixir blog to haskell in a smooth way. So far the only problem I really struggled is this: Strings being utf8 encoded by default, the regexes have very weird behavior. For instance

``` purescript
replace (unsafeRegex "à" noFlag) "a" "à table" == "ys table" -- you'd expect "a table" right?
replace (unsafeRegex "à" unicode) "a" "à table" == "a table" -- better!
```

I guess my modification might not be the best, but I wanted to know whether you'd agree on changing this behavior? If you guide me a little I can make the PR a bit better, code quality wise.