### PR TITLE
Update CodePoints.purs

### DIFF
--- a/src/Data/String/CodePoints.purs
+++ b/src/Data/String/CodePoints.purs
@@ -319,7 +319,7 @@ lastIndexOf' p i s =
 -- | ```
 -- |
 take :: Int -> String -> String
-take = _take takeFallback
+take i = _take takeFallback (if i > 0 then i else 0)
 
 foreign import _take :: (Int -> String -> String) -> Int -> String -> String
 


### PR DESCRIPTION
**Description of the change**

There's a bug here. If you CodePoint.drop a negative amount we eventually call something like `lists:sublist([1,2,3], -1)` which crashes. I don't know if this fix compiles, but it shows what's up anyway.