### PR TITLE
Use modern Erlang string functions in Data.String.Regex

### DIFF
--- a/src/Data/String/Regex.erl
+++ b/src/Data/String/Regex.erl
@@ -11,8 +11,8 @@ flags_to_options([$y|Flags], Acc) -> flags_to_options(Flags, Acc);
 flags_to_options([$u|Flags], Acc) -> flags_to_options(Flags, [ucp|[unicode|Acc]]);
 flags_to_options(_,_) -> err.
 
-is_global(S) -> case string:chr(unicode:characters_to_list(S), $g) of
-  0 -> false;
+is_global(S) -> case string:find(S, <<"g"/utf8>>) of
+  nomatch -> false;
   _ -> true
 end.
 
@@ -54,6 +54,7 @@ end.
 replace({R,{_,F}},S1,S2) ->
   G = case is_global(F) of true -> [global]; false -> [] end,
   re:replace(S2,R,S1,G++[{return,binary}]).
+
 % TODO
 '_replaceBy'(_Just,_Nothing,{_R,_},_F,_S2) -> error("_replaceBy not supported").
 
@@ -62,9 +63,9 @@ replace({R,{_,F}},S1,S2) ->
   _ -> Nothing
 end.
 
-split({R,RS},S) ->
+split({R,RS},S) ->   % should RS be {RS,_Flags} here?
   Res = re:split(S,R),
   Res1 = case RS of
-    "" -> lists:droplast(Res);
+    "" -> lists:droplast(Res);  % special case for when regexp was empty?
     _ -> Res end,
   array:from_list(Res1).


### PR DESCRIPTION
Drop use of obsolete string:chr().

Added comment on probable bug in split. Should be resolved before merging.


---

**Checklist:**

- [ ] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
